### PR TITLE
support tenant 0 whitelist + CSP header smint.io

### DIFF
--- a/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
+++ b/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
@@ -28,7 +28,7 @@ namespace HCore.Identity.Attributes
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
                 var csp = "default-src 'self' https://*.smint.io https://*.smint.io; " +
                           "object-src 'none'; " +
-                          "frame-ancestors 'self' https://*.sharepoint.com https://*.officeapps.live.com; " +
+                          "frame-ancestors 'self' https://*.smint.io https://*.sharepoint.com https://*.officeapps.live.com; " +
                           "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.smint.io https://code.jquery.com https://unpkg.com https://w.chatlio.com https://js.pusher.com https://cdn.segment.com https://www.google.com https://www.gstatic.com https://*.pusher.com; " +
                           "connect-src 'self' *; " +
                           "style-src 'self' 'unsafe-inline' https://*.smint.io https://fonts.googleapis.com https://unpkg.com https://w.chatlio.com; " +

--- a/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
+++ b/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
@@ -28,7 +28,7 @@ namespace HCore.Identity.Attributes
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
                 var csp = "default-src 'self' https://*.smint.io https://*.smint.io; " +
                           "object-src 'none'; " +
-                          "frame-ancestors 'self' https://*.smint.io https://*.sharepoint.com https://*.officeapps.live.com; " +
+                          "frame-ancestors 'self' https://*.smint.io:40443 https://*.smint.io https://*.sharepoint.com https://*.officeapps.live.com; " +
                           "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.smint.io https://code.jquery.com https://unpkg.com https://w.chatlio.com https://js.pusher.com https://cdn.segment.com https://www.google.com https://www.gstatic.com https://*.pusher.com; " +
                           "connect-src 'self' *; " +
                           "style-src 'self' 'unsafe-inline' https://*.smint.io https://fonts.googleapis.com https://unpkg.com https://w.chatlio.com; " +

--- a/HCore-Tenants/Middleware/TenantMiddleware.cs
+++ b/HCore-Tenants/Middleware/TenantMiddleware.cs
@@ -81,10 +81,10 @@ namespace HCore.Tenants.Middleware
 
                     // only allow the tenant selector fallback URL on the tenant selector tenant
 
-                    var path = context.Request.GetEncodedUrl();
+                    var url = context.Request.GetEncodedUrl();
 
-                    if (string.IsNullOrEmpty(path) ||
-                        (!path.EndsWith(".css") && !string.Equals(path, _tenantSelectorFallbackUrl)))
+                    if (string.IsNullOrEmpty(url) ||
+                        (!url.EndsWith(".css") && !string.Equals(url, _tenantSelectorFallbackUrl)))
                     {
                         throw new NotFoundApiException(NotFoundApiException.TenantNotFound, $"The tenant for host {host} was not found", host);
                     }


### PR DESCRIPTION
In order to support Office365 add-ins even better, the following have been implemented:

* support for a whitelist regular expression of allowed URLs of tenant 0
* add `*.smint.io` to the list of allowed iframe parents in CSP header

All this, because Office365 add-in makes use of a wrapping iframe layer, in order to overcome syntax restrictions of the manifest XML. It does not support wildcards of allowed domains. Nevertheless all domains are allowed if loaded inside an iframe.