### PR TITLE
fix:(office365) remove CSP header value "sandbox"

### DIFF
--- a/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
+++ b/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
@@ -36,7 +36,6 @@ namespace HCore.Identity.Attributes
                           "frame-src 'self' https://*.smint.io https://www.google.com; " +
                           "img-src * data:; " +
                           "media-src *; " +
-                          "sandbox allow-forms allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox; " +
                           "base-uri 'self'; " +
                           "upgrade-insecure-requests;";
 


### PR DESCRIPTION
fix:(office365) remove CSP header value "sandbox"
    
The "sandbox" CSP value puts any loaded iframe into sandbox mode.
Hence the office365 iframe will not be able to access its parent
window. This is required for the Smint.io Office365 iframe layer,
that will help in handling dozens of client related sub-domains
without the need to publish a new add-in for every new sub-domain.
    
At the moment the security-risk seems negligible as other
(frame) restrictions still apply. However, this needs to be
investigated and carefully monitored.
