### PR TITLE
fix:(office365) remove X-Frame-Options header

### DIFF
--- a/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
+++ b/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
@@ -19,12 +19,6 @@ namespace HCore.Identity.Attributes
                     context.HttpContext.Response.Headers.Add("X-Content-Type-Options", "nosniff");
                 }
 
-                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
-                if (!context.HttpContext.Response.Headers.ContainsKey("X-Frame-Options"))
-                {
-                    context.HttpContext.Response.Headers.Add("X-Frame-Options", "sameorigin");
-                }
-
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
                 var csp = "default-src 'self' https://*.smint.io https://*.smint.io; " +
                           "object-src 'none'; " +


### PR DESCRIPTION
The X-Frame-Options header is deprecated and is obsoleted
by Content Security Policy (CSP). Since identity server already
provides CSP header, the X-Frame-Options header is totally ignored
by all modern browsers. Additionally the implementation of the support of
this header is crap in most browsers!

Unfortunately, IE11 does not support CSP and thus does not
ignore this header. The header provides no any
flexibility to allow a sibling domain or any wildcard domain
to open the page within an iframe. So it is totally useless in that
respect. It is hop or drop - either load within iframe or not.

Since Office365 add-ins are loaded inside an iframe and executed
by an IE11 host in MS-Windows, the header will prevent them from
being executed on Windows. Hence it is removed.