### PR TITLE
fix:(office365) remove default X-Frame-Option header of .NET core

### DIFF
--- a/HCore-Web/Startup/Startup.cs
+++ b/HCore-Web/Startup/Startup.cs
@@ -145,6 +145,7 @@ namespace HCore.Web.Startup
                 {
                     options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
                     options.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Strict;
+                    options.SuppressXFrameOptionsHeader = true;
                 });
 
                 services.AddHsts(options =>


### PR DESCRIPTION
The .NET core anti forgery settings send this header by default.
So the header must be explicitly turned off.

see commit fix:(office365) remove X-Frame-Options header
0f29450c3ee1b63c8f4a77bf9f73f154c085f1e1

Since Office365 add-ins are loaded inside an iframe and executed
by an IE11 host in MS-Windows, the header will prevent them from
being executed on Windows. Hence it is removed.