### PR TITLE
fix(web): TLS "CipherPolicy" is supported on Mac OS

### DIFF
--- a/HCore-Web/Startup/Launcher.cs
+++ b/HCore-Web/Startup/Launcher.cs
@@ -235,8 +235,7 @@ namespace HCore.Web.Startup
                     {
                         httpsOptions.SslProtocols = System.Security.Authentication.SslProtocols.Tls12 | System.Security.Authentication.SslProtocols.Tls13;
 
-                        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows) &&
-                            !System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+                        if (!System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
                         {
                             var allowedCipherSuites = CipherSuitesPolicy.AllowedCipherSuites;
                             


### PR DESCRIPTION
Setting "Cipher Policy" is supported on Mac OS. Hence the
check for this can be safely removed and is removed.