### PR TITLE
feature:(tenant) skip tenant selector if called on tenant host

### DIFF
--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Tenant.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Tenant.cshtml.cs
@@ -29,13 +29,25 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         public IActionResult OnGet()
         {
-            if (Request.Cookies.ContainsKey(CookieName))
+            string tenantName = null;
+
+            var hostName = HttpContext.Request.Host.Host.Split('.')[0].ToLower();
+
+            if (hostName != "login" && hostName != "development-login")
+            {
+                tenantName = hostName;
+
+            }
+            else if (Request.Cookies.ContainsKey(CookieName))
+            {
+                tenantName = Request.Cookies[CookieName];
+            }
+
+            if (!String.IsNullOrWhiteSpace(tenantName))
             {
                 try
                 {
-                    string domain = Request.Cookies[CookieName];
-
-                    return HandleDomain(domain);
+                    return HandleDomain(tenantName);
                 } 
                 catch (Exception)
                 {


### PR DESCRIPTION
If the tenant selector page is called on the tenant host name,
then the tenant host name is used as selector and the selector
page is being skipped.

The cookie as selector is only used if host name is either
"develop-login" or "login".