### PR TITLE
enable office365 on the web inside IE11 Win7

### DIFF
--- a/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
+++ b/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
@@ -27,6 +27,11 @@ namespace HCore.Identity.Attributes
                     context.HttpContext.Response.Headers.Add("X-Content-Type-Options", "nosniff");
                 }
 
+                if (!context.HttpContext.Response.Headers.ContainsKey("P3P"))
+                {
+                    context.HttpContext.Response.Headers.Add("P3P", "CP=\"This is not a P3P policy!\"");
+                }
+
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
                 var csp = "default-src 'self' https://*.smint.io https://*.smint.io; " +
                           "object-src 'none'; " +

--- a/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
+++ b/HCore-Identity/Attributes/SecurityHeadersAttribute.cs
@@ -19,7 +19,7 @@ namespace HCore.Identity.Attributes
         {
             var result = context.Result;
 
-            if (result is ViewResult || result is PageResult)
+            if (result is ViewResult || result is PageResult || result is LocalRedirectResult)
             {
                 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
                 if (!context.HttpContext.Response.Headers.ContainsKey("X-Content-Type-Options"))


### PR DESCRIPTION
Office365 loads add-ins inside an iframe. To make iframes work with cookies, additional measurements need to be taken:

* add a dummy P3P header to turn on 3rd-party cookies in IE11
* ensure that all redirect answers have the HTTP security headers applied too. Only then the authentication cookie will be accepted and used.

