### PR TITLE
feature:(web) search for HTML template file in sub-directories, too

### DIFF
--- a/HCore-Web/Providers/Impl/HtmlIncludesTemplateDetectorProviderImpl.cs
+++ b/HCore-Web/Providers/Impl/HtmlIncludesTemplateDetectorProviderImpl.cs
@@ -93,7 +93,7 @@ namespace HCore.Web.Providers.Impl
             List<(string, string)> allHtmlFiles = new List<(string, string)>();
 
             var baseDir = GetRootPath();
-            foreach (string file in Directory.EnumerateFiles(baseDir, "*.html", SearchOption.TopDirectoryOnly))
+            foreach (string file in Directory.EnumerateFiles(baseDir, "*.html", SearchOption.AllDirectories))
             {
                 // do something
                 allHtmlFiles.Add((file.Substring(baseDir.Length), file));


### PR DESCRIPTION
Looking fr HTML templates in top directory only, is a tough restrictions
of MPA pages. The fact is, that many MPA pages are located within
subdirectories. So, the HTML template files need to do the same.