### PR TITLE
page models provide model data via json

### DIFF
--- a/HCore-Identity-PagesUI-Classes/Pages/Account/BasePageModelProvidingJsonModelData.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/BasePageModelProvidingJsonModelData.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using HCore.Translations.Resources;
+
+namespace HCore.Identity.PagesUI.Classes.Pages.Account
+{
+    public abstract class BasePageModelProvidingJsonModelData : PageModel
+    {
+        public abstract string Values { get; }
+
+        public virtual string ValidationErrors =>
+            JsonConvert.SerializeObject(
+                GetValidationErrors(), 
+                new JsonSerializerSettings()
+                {
+                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                }
+            )
+        ;
+
+        private List<string> GetValidationErrors()
+        {
+            var result = new List<string>();
+
+            foreach (var value in ModelState.Values)
+            {
+                if (value.Errors != null)
+                {
+                    foreach (var error in value.Errors)
+                    {
+                        if (!string.IsNullOrEmpty(error.ErrorMessage))
+                            result.Add(error.ErrorMessage);
+                        else if (error.Exception != null)
+                            result.Add(Messages.internal_server_error);
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/BasePageModelProvidingJsonModelData.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/BasePageModelProvidingJsonModelData.cs
@@ -7,7 +7,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 {
     public abstract class BasePageModelProvidingJsonModelData : PageModel
     {
-        public abstract string Values { get; }
+        public abstract string ModelAsJson { get; }
 
         public virtual string ValidationErrors =>
             JsonConvert.SerializeObject(

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/BasePageModelProvidingJsonModelData.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/BasePageModelProvidingJsonModelData.cs
@@ -9,7 +9,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
     {
         public abstract string ModelAsJson { get; }
 
-        public virtual string ValidationErrors =>
+        public virtual string ValidationErrorsAsJson =>
             JsonConvert.SerializeObject(
                 GetValidationErrors(), 
                 new JsonSerializerSettings()

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/ConfirmEmail.cshtml.cs
@@ -6,11 +6,12 @@ using HCore.Web.Exceptions;
 using HCore.Identity.Models;
 using HCore.Identity.Services;
 using HCore.Translations.Providers;
+using Newtonsoft.Json;
 
 namespace HCore.Identity.PagesUI.Classes.Pages.Account
 {
     [SecurityHeaders]
-    public class ConfirmEmailModel : PageModel
+    public class ConfirmEmailModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
         private readonly ITranslationsProvider _translationsProvider;
@@ -22,6 +23,8 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             _identityServices = identityServices;
             _translationsProvider = translationsProvider;
         }
+
+        public override string Values { get; } = "{}";
 
         public async Task<IActionResult> OnGetAsync(string userUuid, string code)
         {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/ConfirmEmail.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/ConfirmEmail.cshtml.cs
@@ -24,7 +24,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             _translationsProvider = translationsProvider;
         }
 
-        public override string Values { get; } = "{}";
+        public override string ModelAsJson { get; } = "{}";
 
         public async Task<IActionResult> OnGetAsync(string userUuid, string code)
         {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/EmailNotConfirmed.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/EmailNotConfirmed.cs
@@ -8,11 +8,12 @@ using HCore.Identity.Services;
 using HCore.Translations.Providers;
 using Microsoft.AspNetCore.DataProtection;
 using System;
+using Newtonsoft.Json;
 
 namespace HCore.Identity.PagesUI.Classes.Pages.Account
 {
     [SecurityHeaders]
-    public class EmailNotConfirmedModel : PageModel
+    public class EmailNotConfirmedModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
         private readonly ITranslationsProvider _translationsProvider;
@@ -28,6 +29,19 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             _translationsProvider = translationsProvider;
 
             _dataProtectionProvider = dataProtectionProvider;
+        }
+
+        public override string Values { get =>
+            JsonConvert.SerializeObject(
+                new
+                {
+                    StatusMessage,
+                    UserUuid = Input.UserUuid,
+                }, new JsonSerializerSettings()
+                {
+                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                }
+            );
         }
 
         [TempData]

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/EmailNotConfirmed.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/EmailNotConfirmed.cs
@@ -31,18 +31,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             _dataProtectionProvider = dataProtectionProvider;
         }
 
-        public override string ModelAsJson { get =>
-            JsonConvert.SerializeObject(
-                new
-                {
-                    StatusMessage,
-                    UserUuid = Input.UserUuid,
-                }, new JsonSerializerSettings()
-                {
-                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
-                }
-            );
-        }
+        public override string ModelAsJson { get; } = "{}";
 
         [TempData]
         public string StatusMessage { get; set; }

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/EmailNotConfirmed.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/EmailNotConfirmed.cs
@@ -31,7 +31,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             _dataProtectionProvider = dataProtectionProvider;
         }
 
-        public override string Values { get =>
+        public override string ModelAsJson { get =>
             JsonConvert.SerializeObject(
                 new
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/ForgotPassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/ForgotPassword.cshtml.cs
@@ -41,7 +41,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         public RecaptchaSettings Recaptcha { get; set; }
         
-        public override string Values { get =>
+        public override string ModelAsJson { get =>
             JsonConvert.SerializeObject(
                 new
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/ForgotPassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/ForgotPassword.cshtml.cs
@@ -45,7 +45,6 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             JsonConvert.SerializeObject(
                 new
                 {
-                    Email = Input.Email,
                     RecaptchaSiteKey = Recaptcha.SiteKey
                 }, new JsonSerializerSettings()
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/ForgotPassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/ForgotPassword.cshtml.cs
@@ -10,11 +10,12 @@ using reCAPTCHA.AspNetCore;
 using System;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 
 namespace HCore.Identity.PagesUI.Classes.Pages.Account
 {
     [SecurityHeaders]
-    public class ForgotPasswordModel : PageModel
+    public class ForgotPasswordModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
         private readonly ITranslationsProvider _translationsProvider;
@@ -40,6 +41,19 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         public RecaptchaSettings Recaptcha { get; set; }
         
+        public override string Values { get =>
+            JsonConvert.SerializeObject(
+                new
+                {
+                    Email = Input.Email,
+                    RecaptchaSiteKey = Recaptcha.SiteKey
+                }, new JsonSerializerSettings()
+                {
+                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                }
+            );
+        }
+
         public async Task<IActionResult> OnPostAsync()
         {
             ModelState.Clear();

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Login.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Login.cshtml.cs
@@ -48,20 +48,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         private readonly IDataProtectionProvider _dataProtectionProvider;
 
-        public override string ModelAsJson { get =>
-            JsonConvert.SerializeObject(
-                new
-                {
-                    Email = Input.Email,
-                    Password = Input.Password,
-                    Remember = Input.Remember,
-                    ReturnUrl,
-                }, new JsonSerializerSettings()
-                {
-                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
-                }
-            );
-        }
+        public override string ModelAsJson { get; } = "{}";
 
         public LoginModel(
             IIdentityServices identityServices,

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Login.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Login.cshtml.cs
@@ -120,9 +120,9 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             return Page();
         }
 
-#pragma warning disable CS1998 // Bei der asynchronen Methode fehlen "await"-Operatoren. Die Methode wird synchron ausgeführt.
+#pragma warning disable CS1998 // This async method is lacking any "await" operator on purpose, thus it is called synchronous.
         private async Task<IActionResult> ChallengeExternalAsync(string externalAuthenticationMethod)
-#pragma warning restore CS1998 // Bei der asynchronen Methode fehlen "await"-Operatoren. Die Methode wird synchron ausgeführt.
+#pragma warning restore CS1998 // This async method is lacking any "await" operator on purpose, thus it is called synchronous.
         {
             // initiate roundtrip to external authentication provider
 

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Login.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Login.cshtml.cs
@@ -30,7 +30,7 @@ using HCore.Translations.Resources;
 namespace HCore.Identity.PagesUI.Classes.Pages.Account
 {
     [SecurityHeaders]
-    public class LoginModel : PageModel
+    public class LoginModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
         private readonly IConfigurationProvider _configurationProvider;
@@ -48,14 +48,20 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         private readonly IDataProtectionProvider _dataProtectionProvider;
 
-        public string ValidationErrors { get =>
+        public override string Values { get =>
             JsonConvert.SerializeObject(
-                GetValidationErrors(), 
-                new JsonSerializerSettings()
+                new
+                {
+                    Email = Input.Email,
+                    Password = Input.Password,
+                    Remember = Input.Remember,
+                    ReturnUrl,
+                }, new JsonSerializerSettings()
                 {
                     StringEscapeHandling = StringEscapeHandling.EscapeHtml
-                });
-            }
+                }
+            );
+        }
 
         public LoginModel(
             IIdentityServices identityServices,
@@ -395,27 +401,6 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
                     segmentClient.Track(user.Id, "Logged in");
                 }
             }
-        }
-
-        private List<string> GetValidationErrors()
-        {
-            var result = new List<string>();
-
-            foreach (var value in ModelState.Values)
-            {
-                if (value.Errors != null)
-                {
-                    foreach (var error in value.Errors)
-                    {
-                        if (!string.IsNullOrEmpty(error.ErrorMessage))
-                            result.Add(error.ErrorMessage);
-                        else if (error.Exception != null)
-                            result.Add(Messages.internal_server_error);
-                    }
-                }
-            }
-            
-            return result;
         }
     }
 }

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Login.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Login.cshtml.cs
@@ -48,7 +48,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         private readonly IDataProtectionProvider _dataProtectionProvider;
 
-        public override string Values { get =>
+        public override string ModelAsJson { get =>
             JsonConvert.SerializeObject(
                 new
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Logout.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Logout.cshtml.cs
@@ -45,7 +45,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         private readonly ITenantInfoAccessor _tenantInfoAccessor;
 
-        public override string Values { get =>
+        public override string ModelAsJson { get =>
             JsonConvert.SerializeObject(
                 new
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Logout.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Logout.cshtml.cs
@@ -50,7 +50,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
                 new
                 {
                     LoggedOut,
-                    PostLogoutRedirectUri
+                    PostLogoutRedirectUri,
                 }, new JsonSerializerSettings()
                 {
                     StringEscapeHandling = StringEscapeHandling.EscapeHtml

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Logout.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Logout.cshtml.cs
@@ -14,7 +14,7 @@ using Newtonsoft.Json;
 namespace HCore.Identity.PagesUI.Classes.Pages.Account
 {
     [SecurityHeaders]
-    public class LogoutModel : PageModel
+    public class LogoutModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
 
@@ -45,7 +45,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         private readonly ITenantInfoAccessor _tenantInfoAccessor;
 
-        public string Values { get =>
+        public override string Values { get =>
             JsonConvert.SerializeObject(
                 new
                 {
@@ -54,8 +54,9 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
                 }, new JsonSerializerSettings()
                 {
                     StringEscapeHandling = StringEscapeHandling.EscapeHtml
-                });
-            }
+                }
+            );
+        }
 
         public LogoutModel(
              IIdentityServices identityServices,

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -9,12 +9,13 @@ using HCore.Web.Exceptions;
 using HCore.Identity.Services;
 using HCore.Identity.Resources;
 using HCore.Translations.Providers;
+using Newtonsoft.Json;
 
 namespace HCore.Identity.PagesUI.Classes.Pages.Account.Manage
 {
     [Authorize]
     [SecurityHeaders]
-    public class ChangePasswordModel : PageModel
+    public class ChangePasswordModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
         private readonly ITranslationsProvider _translationsProvider;
@@ -25,6 +26,22 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account.Manage
         {
             _identityServices = identityServices;
             _translationsProvider = translationsProvider;
+        }
+
+        public override string Values { get =>
+            JsonConvert.SerializeObject(
+                new
+                {
+                    PasswordChangePossible,
+                    StatusMessage,
+                    Input.NewPassword,
+                    Input.OldPassword,
+                    Input.NewPasswordConfirmation,
+                }, new JsonSerializerSettings()
+                {
+                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                }
+            );
         }
 
         [BindProperty]

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -28,7 +28,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account.Manage
             _translationsProvider = translationsProvider;
         }
 
-        public override string Values { get =>
+        public override string ModelAsJson { get =>
             JsonConvert.SerializeObject(
                 new
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -34,9 +34,6 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account.Manage
                 {
                     PasswordChangePossible,
                     StatusMessage,
-                    Input.NewPassword,
-                    Input.OldPassword,
-                    Input.NewPasswordConfirmation,
                 }, new JsonSerializerSettings()
                 {
                     StringEscapeHandling = StringEscapeHandling.EscapeHtml

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/Index.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/Index.cshtml.cs
@@ -10,12 +10,13 @@ using HCore.Identity.Database.SqlServer.Models.Impl;
 using HCore.Identity.Services;
 using HCore.Identity.Resources;
 using HCore.Translations.Providers;
+using Newtonsoft.Json;
 
 namespace HCore.Identity.PagesUI.Classes.Pages.Account.Manage
 {
     [Authorize]
     [SecurityHeaders]
-    public partial class IndexModel : PageModel
+    public partial class IndexModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
         private readonly ITranslationsProvider _translationsProvider;
@@ -27,6 +28,34 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account.Manage
             _identityServices = identityServices;
             _translationsProvider = translationsProvider;
         }
+
+        public override string Values { get =>
+            JsonConvert.SerializeObject(
+                new
+                {
+                    Input.FirstName,
+                    Input.LastName,
+                    Input.Password,
+                    Input.PasswordConfirmation,
+                    Email,
+                    EmailConfirmed,
+                    Input.Currency,
+                    Input.AcceptCommunication,
+                    Input.GroupNotifications,
+                    Input.NotificationCulture,
+                    Input.PhoneNumber,
+                    Input.PhoneNumberConfirmed,
+                    Input.AcceptPrivacyPolicy,
+                    Input.AcceptTermsAndConditions,
+                    Input.SegmentAnonymousUserUuid,
+                    StatusMessage,
+                }, new JsonSerializerSettings()
+                {
+                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                }
+            );
+        }
+
 
         [TempData]
         public string StatusMessage { get; set; }

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/Index.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/Index.cshtml.cs
@@ -33,21 +33,6 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account.Manage
             JsonConvert.SerializeObject(
                 new
                 {
-                    Input.FirstName,
-                    Input.LastName,
-                    Input.Password,
-                    Input.PasswordConfirmation,
-                    Email,
-                    EmailConfirmed,
-                    Input.Currency,
-                    Input.AcceptCommunication,
-                    Input.GroupNotifications,
-                    Input.NotificationCulture,
-                    Input.PhoneNumber,
-                    Input.PhoneNumberConfirmed,
-                    Input.AcceptPrivacyPolicy,
-                    Input.AcceptTermsAndConditions,
-                    Input.SegmentAnonymousUserUuid,
                     StatusMessage,
                 }, new JsonSerializerSettings()
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/Index.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Manage/Index.cshtml.cs
@@ -29,7 +29,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account.Manage
             _translationsProvider = translationsProvider;
         }
 
-        public override string Values { get =>
+        public override string ModelAsJson { get =>
             JsonConvert.SerializeObject(
                 new
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Register.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Register.cshtml.cs
@@ -29,7 +29,7 @@ using HCore.Translations.Resources;
 namespace HCore.Identity.PagesUI.Classes.Pages.Account
 {
     [SecurityHeaders]
-    public class RegisterModel : PageModel
+    public class RegisterModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
         private readonly IConfigurationProvider _configurationProvider;        
@@ -43,7 +43,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         private readonly IDataProtectionProvider _dataProtectionProvider;
 
-        public string Values { get =>
+        public override string Values { get =>
             JsonConvert.SerializeObject(
                 new
                 {
@@ -55,17 +55,9 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
                 }, new JsonSerializerSettings()
                 {
                     StringEscapeHandling = StringEscapeHandling.EscapeHtml
-                });
-            }
-
-        public string ValidationErrors { get =>
-            JsonConvert.SerializeObject(
-                GetValidationErrors(), 
-                new JsonSerializerSettings()
-                {
-                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
-                });
-            }
+                }
+            );
+        }
 
         public RegisterModel(
             IIdentityServices identityServices,
@@ -335,27 +327,6 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             {
                 return null;
             }
-        }
-
-        private List<string> GetValidationErrors()
-        {
-            var result = new List<string>();
-
-            foreach (var value in ModelState.Values)
-            {
-                if (value.Errors != null)
-                {
-                    foreach (var error in value.Errors)
-                    {
-                        if (!string.IsNullOrEmpty(error.ErrorMessage))
-                            result.Add(error.ErrorMessage);
-                        else if (error.Exception != null)
-                            result.Add(Messages.internal_server_error);
-                    }
-                }
-            }
-
-            return result;
         }
     }
 }

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/Register.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/Register.cshtml.cs
@@ -43,7 +43,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
 
         private readonly IDataProtectionProvider _dataProtectionProvider;
 
-        public override string Values { get =>
+        public override string ModelAsJson { get =>
             JsonConvert.SerializeObject(
                 new
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/ResetPassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/ResetPassword.cshtml.cs
@@ -24,20 +24,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             _translationsProvider = translationsProvider;
         }
 
-        public override string ModelAsJson { get =>
-            JsonConvert.SerializeObject(
-                new
-                {
-                    Code = Input.Code,
-                    Email = Input.Email,
-                    Password = Input.Password,
-                    PasswordConfirmation = Input.PasswordConfirmation,
-                }, new JsonSerializerSettings()
-                {
-                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
-                }
-            );
-        }
+        public override string ModelAsJson { get; } = "{}";
 
         [BindProperty]
         public ResetUserPasswordSpec Input { get; set; }

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/ResetPassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/ResetPassword.cshtml.cs
@@ -24,7 +24,7 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
             _translationsProvider = translationsProvider;
         }
 
-        public override string Values { get =>
+        public override string ModelAsJson { get =>
             JsonConvert.SerializeObject(
                 new
                 {

--- a/HCore-Identity-PagesUI-Classes/Pages/Account/ResetPassword.cshtml.cs
+++ b/HCore-Identity-PagesUI-Classes/Pages/Account/ResetPassword.cshtml.cs
@@ -6,11 +6,12 @@ using HCore.Identity.Models;
 using HCore.Web.Exceptions;
 using HCore.Identity.Services;
 using HCore.Translations.Providers;
+using Newtonsoft.Json;
 
 namespace HCore.Identity.PagesUI.Classes.Pages.Account
 {
     [SecurityHeaders]
-    public class ResetPasswordModel : PageModel
+    public class ResetPasswordModel : BasePageModelProvidingJsonModelData
     {
         private readonly IIdentityServices _identityServices;
         private readonly ITranslationsProvider _translationsProvider;
@@ -21,6 +22,21 @@ namespace HCore.Identity.PagesUI.Classes.Pages.Account
         {
             _identityServices = identityServices;
             _translationsProvider = translationsProvider;
+        }
+
+        public override string Values { get =>
+            JsonConvert.SerializeObject(
+                new
+                {
+                    Code = Input.Code,
+                    Email = Input.Email,
+                    Password = Input.Password,
+                    PasswordConfirmation = Input.PasswordConfirmation,
+                }, new JsonSerializerSettings()
+                {
+                    StringEscapeHandling = StringEscapeHandling.EscapeHtml
+                }
+            );
         }
 
         [BindProperty]


### PR DESCRIPTION
In order to support JavaScript based UI pages, all pages provide their model data via JSON string, as well. This JSON string can be embedded into the HTML page as JavaScript code. Then it can be used with any JavaScript creating the UI, like Vue/Angular/React.

To maintain a common interface, all model classes use a common base class `BasePageModelProvidingJsonModelData`, which is being introduced with this commmit.
