### PR TITLE
refact:(search) upgrade elastic search client NEST to 7.7.1

### DIFF
--- a/HCore-Database/ElasticSearch/Impl/ConcatenateTokenFilter.cs
+++ b/HCore-Database/ElasticSearch/Impl/ConcatenateTokenFilter.cs
@@ -29,8 +29,10 @@ namespace HCore.Database.ElasticSearch.Impl
         string IConcatenateTokenFilter.TokenSeparator { get; set; }
         int? IConcatenateTokenFilter.IncrementGap { get; set; }
 
-        public ConcatenateTokenFilterDescriptor TokenSeparator(string tokenSeparator) => Assign(a => a.TokenSeparator = tokenSeparator);
+        public ConcatenateTokenFilterDescriptor TokenSeparator(string tokenSeparator) =>
+            Assign(tokenSeparator, (a, v) => a.TokenSeparator = v);
 
-        public ConcatenateTokenFilterDescriptor IncrementGap(int? incrementGap) => Assign(a => a.IncrementGap = incrementGap);
+        public ConcatenateTokenFilterDescriptor IncrementGap(int? incrementGap) =>
+            Assign(incrementGap, (a, v) => a.IncrementGap = v);
     }
 }

--- a/HCore-Database/ElasticSearch/Impl/ElasticSearchClientImpl.cs
+++ b/HCore-Database/ElasticSearch/Impl/ElasticSearchClientImpl.cs
@@ -96,13 +96,13 @@ namespace HCore.Database.ElasticSearch.Impl
 
         private void CreateIndexVersionsIndex()
         {
-            var indexVersionsIndexExists = ElasticClient.IndexExists(IndexVersionsIndexName).Exists;
+            var indexVersionsIndexExists = ElasticClient.Indices.Exists(IndexVersionsIndexName).Exists;
             
             if (!indexVersionsIndexExists)
             {
                 Console.WriteLine("Creating index versions index...");
 
-                var createIndexResponse = ElasticClient.CreateIndex(IndexVersionsIndexName, indexVersionsIndex => indexVersionsIndex
+                var createIndexResponse = ElasticClient.Indices.Create(IndexVersionsIndexName, indexVersionsIndex => indexVersionsIndex
                     .Mappings(indexVersionMapping => indexVersionMapping
                         .Map<IndexVersion>(indexVersion => indexVersion
                             .Properties(indexVersionProperty => indexVersionProperty
@@ -133,7 +133,7 @@ namespace HCore.Database.ElasticSearch.Impl
 
             createIndexDescriptor = createIndexDescriptor.Index(newIndexNameWithVersion);
 
-            var createIndexResponse = ElasticClient.CreateIndex(newIndexNameWithVersion, index => createIndexDescriptor);
+            var createIndexResponse = ElasticClient.Indices.Create(newIndexNameWithVersion, index => createIndexDescriptor);
 
             Console.WriteLine($"Index {newIndexNameWithVersion} created");
             
@@ -156,7 +156,7 @@ namespace HCore.Database.ElasticSearch.Impl
                     $"({reindexOnServerResult.Created} created, {reindexOnServerResult.Updated} updated)");
             }
 
-            var aliasExists = ElasticClient.AliasExists(indexName).Exists;
+            var aliasExists = ElasticClient.Indices.AliasExists(indexName).Exists;
 
             if (aliasExists)
             {
@@ -164,7 +164,7 @@ namespace HCore.Database.ElasticSearch.Impl
 
                 Console.WriteLine($"Deleting alias {indexName} -> {oldIndexNameWithVersion}...");
 
-                ElasticClient.DeleteAlias(oldIndexNameWithVersion, indexName);
+                ElasticClient.Indices.DeleteAlias(oldIndexNameWithVersion, indexName);
 
                 Console.WriteLine($"Deleted alias {indexName} -> {oldIndexNameWithVersion}");
             }
@@ -173,7 +173,7 @@ namespace HCore.Database.ElasticSearch.Impl
 
             Console.WriteLine($"Creating alias {indexName} -> {newIndexNameWithVersion}...");
 
-            var createAliasResponse = ElasticClient.Alias(alias => alias
+            var createAliasResponse = ElasticClient.Indices.BulkAlias(alias => alias
                 .Add(action => action
                     .Index(newIndexNameWithVersion)
                     .Alias(indexName)
@@ -203,7 +203,7 @@ namespace HCore.Database.ElasticSearch.Impl
 
                     Console.WriteLine($"Deleting old index {oldIndexNameWithVersion}");
 
-                    var deleteIndexResponse = ElasticClient.DeleteIndex(oldIndexNameWithVersion);
+                    var deleteIndexResponse = ElasticClient.Indices.Delete(oldIndexNameWithVersion);
 
                     if (!deleteIndexResponse.Acknowledged)
                         throw new Exception($"Cannot delete old index {oldIndexNameWithVersion}");

--- a/HCore-Database/HCore-Database.csproj
+++ b/HCore-Database/HCore-Database.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
-    <PackageReference Include="NEST" Version="6.6.0" />
+    <PackageReference Include="NEST" Version="7.7.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0" />
 	<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.43" />
   </ItemGroup>


### PR DESCRIPTION
Unfortunately the documentation of the API reference is
very bad. The following functions have been changed but the
proper adaption has only been guessed. The guess might be
wrong.

* `Assign` -> new parameter to set the value, which will then
   be passed to the setter function. Correct?
* `ElasticClient.Alias` -> replaced by ? `ElasticClient.Indices.BulkAlias`