### PR TITLE
fix:(elasticsearch) set index configuration max_ngram_diff to int.MaxValue

### DIFF
--- a/HCore-Database/ElasticSearch/Impl/ElasticSearchClientImpl.cs
+++ b/HCore-Database/ElasticSearch/Impl/ElasticSearchClientImpl.cs
@@ -219,6 +219,7 @@ namespace HCore.Database.ElasticSearch.Impl
             return setting
                 .NumberOfShards(_numberOfShards)
                 .NumberOfReplicas(_numberOfReplicas)
+                .Setting("index.max_ngram_diff", int.MaxValue)
                 .Setting("index.gc_deletes", "1h"); // 1 hour
         }
 
@@ -228,6 +229,7 @@ namespace HCore.Database.ElasticSearch.Impl
                 .NumberOfShards(_numberOfShards)
                 .NumberOfReplicas(_numberOfReplicas)
                 .Analysis(analysis => ConfigureConcatenateAndAutocompleteAnalysis(analysis))
+                .Setting("index.max_ngram_diff", int.MaxValue)
                 .Setting("index.gc_deletes", "1h"); // 1 hour
         }
 


### PR DESCRIPTION

With ElasticSearch 6.0 NGram diffs more than 1 have been deprecated.
From version 7.0 onwards, the deprecation throws an exception in case the
index is created. Older indexes are not touched and no exception
thrown for their high ngram diff value.

So, when starting ElasticSearch database from scratch, startup crashes.

see:
* https://github.com/elastic/elasticsearch/pull/27411
* https://github.com/mayya-sharipova/elasticsearch/blob/master/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/NGramTokenFilterFactory.java