### PR TITLE
feature:(web) implement a download URL proxy wrapper provider

### DIFF
--- a/HCore-Web/Providers/IDownloadProcessingProxyUrlProvider.cs
+++ b/HCore-Web/Providers/IDownloadProcessingProxyUrlProvider.cs
@@ -59,7 +59,7 @@ namespace HCore.Web.Providers
 
     public interface IDownloadFileData
     {
-        public Stream data { get; }
+        public Stream Data { get; }
         public string FileName { get; }
         public string MimeType { get; }
         public string CharacterSet { get; }

--- a/HCore-Web/Providers/IDownloadProcessingProxyUrlProvider.cs
+++ b/HCore-Web/Providers/IDownloadProcessingProxyUrlProvider.cs
@@ -42,7 +42,6 @@ namespace HCore.Web.Providers
         /// sort of processing pipe.</remarks>
         /// </summary>
         /// <param name="request">The HTTP request to read request data from.</param>
-        /// like setting proper MIME type or that alike.</param>
         /// <param name="inputData">(optional) Contains the file data as processed by the previous stage. If
         /// <code>null</code>, then it will be returned unchanged.</param>
         /// <returns>The file data as a stream to be piped to the next processing stage.</returns>

--- a/HCore-Web/Providers/IDownloadProcessingProxyUrlProvider.cs
+++ b/HCore-Web/Providers/IDownloadProcessingProxyUrlProvider.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace HCore.Web.Providers
+{
+    /// <summary>
+    /// Defines a service to facade downloads with a download proxy, which might perform some processing of downloads.
+    ///
+    /// <remarks>There is a need for some downloads from external sources to rename the download file name.
+    /// Unfortunately this is not possible with external URLs. Only a proxy facade may do so by
+    /// downloading the file data on behalf of the user and passing it with a changed name.</remarks>
+    ///
+    /// <remarks>More processing is possible, of course.</remarks>
+    /// </summary>
+    public interface IDownloadProcessingProxyUrlProvider
+    {
+        /// <summary>
+        /// Takes an external URI and creates a new one that utilizes the processing proxy downloader.
+        ///
+        /// <remarks>Somehow the external source URI must be passed to the download processing proxy. It would be
+        /// best to use .NET core data protector to do so and use data protector with the companion proxy function
+        /// to decode the data back to original source URI.</remarks>
+        ///
+        /// <remarks>More processing is possible, of course.</remarks>
+        /// </summary>
+        /// <param name="downloadSourceUri">The source URI to download the file data from.</param>
+        /// <param name="fileName">The file name to use for downloading.</param>
+        /// <param name="proxyBaseUrl">The base URL of the proxy controller receiving the reverse proxy request.</param>
+        /// <param name="downloadMimeType">(optional) the mime type to set for the download file.</param>
+        /// <returns>An URI to be passed to clients that will download the file from the processing proxy.</returns>
+        public Task<Uri> CreateProxyUrlAsync(Uri downloadSourceUri, string fileName, string proxyBaseUrl, string downloadMimeType = null);
+
+        /// <summary>
+        /// Downloads the original file data based on the request data, processes the file data and configures the
+        /// response accordingly.
+        ///
+        /// <remarks>For better stacked processing, the output is not directly written to the response
+        /// but returned as a stream. Then this function can be stacked with other download processors to form some
+        /// sort of processing pipe.</remarks>
+        /// </summary>
+        /// <param name="request">The HTTP request to read request data from.</param>
+        /// like setting proper MIME type or that alike.</param>
+        /// <param name="inputData">(optional) Contains the file data as processed by the previous stage. If
+        /// <code>null</code>, then it will be returned unchanged.</param>
+        /// <returns>The file data as a stream to be piped to the next processing stage.</returns>
+        public Task<IDownloadFileData> GetFileDataAsync(HttpRequest request, Stream inputData);
+
+        /// <summary>
+        /// Returns the original source URI of the file to download, as read from the HTTP request data and decoded
+        /// with data protection facility of .NET core.
+        /// </summary>
+        /// <param name="request">The HTTP request to read request data from.</param>
+        /// <returns>The original source URI of the download file.</returns>
+        public Uri GetSourceUri(HttpRequest request);
+    }
+
+    public interface IDownloadFileData
+    {
+        public Stream data { get; }
+        public string FileName { get; }
+        public string MimeType { get; }
+        public string CharacterSet { get; }
+    }
+}

--- a/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
+++ b/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using static System.Convert;
-using static Newtonsoft.Json.JsonConvert;
 
 namespace HCore.Web.Providers.Impl
 {
@@ -143,7 +142,7 @@ namespace HCore.Web.Providers.Impl
             return new Uri(request.Query["u"]);
         }
 
-        private dynamic ConvertParametersFromQueryData(HttpRequest request)
+        private string ConvertParametersFromQueryData(HttpRequest request)
         {
             if (request == null)
             {
@@ -155,16 +154,14 @@ namespace HCore.Web.Providers.Impl
                 return null;
             }
 
-            string protectedJson = queryData[0];
-            string json = _protector.Unprotect(protectedJson);
-            return DeserializeObject<dynamic>(json);
+            string protectedHash = queryData[0];
+            return _protector.Unprotect(protectedHash);
         }
 
-        private string ConvertParametersToQueryData(dynamic downloadParameters)
+        private string ConvertParametersToQueryData(string hash)
         {
-            string json = SerializeObject(downloadParameters);
-            string protectedJson = _protector.Protect(json);
-            return $"{UrlQueryKeyName}={Uri.EscapeDataString(protectedJson)}" ;
+            string protectedHash = _protector.Protect(hash);
+            return $"{UrlQueryKeyName}={Uri.EscapeDataString(protectedHash)}" ;
         }
 
         private string CalculateHashFromParameters(Uri downloadSourceUri, string fileName, string downloadMimeType = null)

--- a/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
+++ b/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
@@ -131,7 +131,7 @@ namespace HCore.Web.Providers.Impl
 
             return new DownloadFileDataImpl()
             {
-                data = fileData,
+                Data = fileData,
                 FileName = fileName,
                 CharacterSet = characterSet,
                 MimeType = mimeType,
@@ -189,7 +189,7 @@ namespace HCore.Web.Providers.Impl
 
     internal class DownloadFileDataImpl : IDownloadFileData
     {
-        public Stream data { get; set; }
+        public Stream Data { get; set; }
         public string FileName { get; set; }
         public string MimeType { get; set; }
         public string CharacterSet { get; set; }

--- a/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
+++ b/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
@@ -183,7 +183,7 @@ namespace HCore.Web.Providers.Impl
         private bool IsHashValid(string hashToVerify, Uri downloadSourceUri, string fileName, string downloadMimeType = null)
         {
             string calculatedHash = CalculateHashFromParameters(downloadSourceUri, fileName, downloadMimeType);
-            return calculatedHash != null && calculatedHash.Equals(hashToVerify);
+            return string.Equals(calculatedHash, hashToVerify);
         }
     }
 

--- a/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
+++ b/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
@@ -28,7 +28,6 @@ namespace HCore.Web.Providers.Impl
     /// </summary>
     public class DownloadProcessingProxyUrlProviderImpl : IDownloadProcessingProxyUrlProvider
     {
-        public static readonly string ProcessingProxyBaseUrlConfig = "DownloadProxy:BaseUrl";
         public static readonly string UrlQueryKeyName = "data";
         public static readonly string UrlQueryKeyMimeType = "mime";
         public static readonly string UrlQueryKeyFileName = "fileName";

--- a/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
+++ b/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
@@ -1,0 +1,197 @@
+﻿using System;
+using System.IO;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using static System.Convert;
+using static Newtonsoft.Json.JsonConvert;
+
+namespace HCore.Web.Providers.Impl
+{
+    /// <summary>
+    /// Defines a service to facade downloads with a download proxy, which might perform some processing of downloads.
+    ///
+    /// <remarks>There is a need for some downloads from external sources to rename the download file name.
+    /// Unfortunately this is not possible with external URLs. Only a proxy facade may do so by
+    /// downloading the file data on behalf of the user and passing it with a changed name.</remarks>
+    ///
+    /// <remarks>More processing is possible, of course.</remarks>
+    /// </summary>
+    public class DownloadProcessingProxyUrlProviderImpl : IDownloadProcessingProxyUrlProvider
+    {
+        public static readonly string ProcessingProxyBaseUrlConfig = "DownloadProxy:BaseUrl";
+        public static readonly string UrlQueryKeyName = "data";
+
+        private readonly ILogger<DownloadProcessingProxyUrlProviderImpl> _logger;
+        private readonly IDataProtector _protector;
+        private readonly IServiceProvider _serviceProvider;
+
+        public DownloadProcessingProxyUrlProviderImpl(
+            IDataProtectionProvider protectionProvider,
+            IServiceProvider serviceProvider,
+            ILogger<DownloadProcessingProxyUrlProviderImpl> logger
+        )
+        {
+            if (protectionProvider == null)
+            {
+                throw new ArgumentNullException(nameof(protectionProvider));
+            }
+
+            _protector = protectionProvider.CreateProtector(nameof(DownloadProcessingProxyUrlProviderImpl));
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+
+        public virtual Task<Uri> CreateProxyUrlAsync(Uri downloadSourceUri, string fileName, string proxyBaseUrl, string downloadMimeType = null)
+        {
+            if (downloadSourceUri == null)
+            {
+                throw new ArgumentNullException(nameof(downloadSourceUri));
+            }
+
+            if (!downloadSourceUri.IsAbsoluteUri)
+            {
+                throw new ArgumentException("Download source URI is not absolute URI!");
+            }
+
+            if (string.IsNullOrEmpty(proxyBaseUrl))
+            {
+                throw new ArgumentException("No proxy base URL has been provided!");
+            }
+
+            // convert the data to JSON string
+            string uriQueryPayload = ConvertParametersToQueryData(CalculateHashFromParameters(downloadSourceUri, fileName, downloadMimeType));
+
+            UriBuilder proxyUri = new UriBuilder(proxyBaseUrl);
+            if (proxyUri.Query != null && proxyUri.Query.Length > 1)
+            {
+                proxyUri.Query = proxyUri.Query.Substring(1) + "&" + uriQueryPayload;
+            }
+            else
+            {
+                proxyUri.Query = uriQueryPayload;
+            }
+
+            proxyUri.Query = proxyUri.Query.Substring(1) + "&fileName=" + Uri.EscapeDataString(fileName)
+                + (downloadMimeType != null ? "&mime=" + Uri.EscapeDataString(downloadMimeType) : "")
+                + "&u=" + Uri.EscapeDataString(downloadSourceUri.ToString())
+            ;
+            return Task.FromResult(proxyUri.Uri);
+        }
+
+        public virtual async Task<IDownloadFileData> GetFileDataAsync(HttpRequest request, Stream inputData)
+        {
+            Uri downloadUri = new Uri(request.Query["u"]);
+            string fileName = request.Query["fileName"];
+            string mimeType = request.Query["mime"];
+            string characterSet = "utf-8";
+            string originalHash = ConvertParametersFromQueryData(request);
+
+            if (!IsHashValid(originalHash, downloadUri, fileName, mimeType))
+            {
+                throw new UnauthorizedAccessException("Invalid query data");
+            }
+
+            Stream fileData = inputData;
+            if (fileData == null)
+            {
+                var remoteRequest = new HttpRequestMessage(HttpMethod.Get, downloadUri);
+                var client = _serviceProvider.GetService<HttpClient>();
+                var response = await client.SendAsync(remoteRequest).ConfigureAwait(false);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    fileData = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
+                    if (string.IsNullOrEmpty(mimeType))
+                    {
+                        mimeType = response.Content.Headers.ContentType.MediaType;
+                    }
+
+                    characterSet = response.Content.Headers.ContentType.CharSet;
+                }
+                else
+                {
+                    _logger.LogError(
+                        $"Failed to download file from source location {downloadUri}. " +
+                        $"file name: {JsonConvert.SerializeObject(fileName)}. " +
+                        $"HTTP result was: {response.StatusCode} {response.ReasonPhrase}, response body: {response.Content}"
+                    );
+
+                    throw new HttpRequestException("Failed to download file from source location!");
+                }
+            }
+
+            return new DownloadFileDataImpl()
+            {
+                data = fileData,
+                FileName = fileName,
+                CharacterSet = characterSet,
+                MimeType = mimeType,
+            };
+        }
+
+        public virtual Uri GetSourceUri(HttpRequest request)
+        {
+            return new Uri(request.Query["u"]);
+        }
+
+        private dynamic ConvertParametersFromQueryData(HttpRequest request)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (!request.Query.TryGetValue(UrlQueryKeyName, out var queryData) || queryData.Count != 1)
+            {
+                return null;
+            }
+
+            string protectedJson = queryData[0];
+            string json = _protector.Unprotect(protectedJson);
+            return DeserializeObject<dynamic>(json);
+        }
+
+        private string ConvertParametersToQueryData(dynamic downloadParameters)
+        {
+            string json = SerializeObject(downloadParameters);
+            string protectedJson = _protector.Protect(json);
+            return $"{UrlQueryKeyName}={Uri.EscapeDataString(protectedJson)}" ;
+        }
+
+        private string CalculateHashFromParameters(Uri downloadSourceUri, string fileName, string downloadMimeType = null)
+        {
+            string valueToHash = $"{fileName}:{downloadMimeType}:{downloadSourceUri}";
+
+            // see https://stackoverflow.com/questions/33245247/hashalgorithms-in-coreclr
+            using var algorithm = SHA256.Create();
+
+            // Create the at_hash using the access token returned by CreateAccessTokenAsync.
+            var hash = algorithm.ComputeHash(Encoding.UTF8.GetBytes(valueToHash));
+
+            return ToBase64String(hash);
+        }
+
+        private bool IsHashValid(string hashToVerify, Uri downloadSourceUri, string fileName, string downloadMimeType = null)
+        {
+            string calculatedHash = CalculateHashFromParameters(downloadSourceUri, fileName, downloadMimeType);
+            return calculatedHash != null && calculatedHash.Equals(hashToVerify);
+        }
+    }
+
+    internal class DownloadFileDataImpl : IDownloadFileData
+    {
+        public Stream data { get; set; }
+        public string FileName { get; set; }
+        public string MimeType { get; set; }
+        public string CharacterSet { get; set; }
+    }
+}

--- a/HCore-Web/Startup/Startup.cs
+++ b/HCore-Web/Startup/Startup.cs
@@ -373,6 +373,7 @@ namespace HCore.Web.Startup
             services.AddScoped<IUrlProvider, UrlProviderImpl>();
             services.AddScoped<INonHttpContextUrlProvider, NonHttpContextUrlProviderImpl>();
             services.AddScoped<INowProvider, NowProviderImpl>();
+            services.AddSingleton<IDownloadProcessingProxyUrlProvider, DownloadProcessingProxyUrlProviderImpl>();
 
             if (UseSpa)
             {


### PR DESCRIPTION
Any URL can be wrapped into a new URL to be downloaded by a
download proxy controller.

The proxy controller uses the same provider to grab the remote
content and set the file data like that:

```
public async Task<IActionResult> DownloadAsync()
{
    var fileData = await _processingProxyProvider.GetFileDataAsync(Request, null);
    return this.File(fileData.data, $"{fileData.MimeType}; charset=${fileData.CharacterSet}", fileData.FileName);
}
```