### PR TITLE
refact:(download-proxy) add lost data protector to protect hash value

### DIFF
--- a/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
+++ b/HCore-Web/Providers/Impl/DownloadProcessingProxyUrlProviderImpl.cs
@@ -94,7 +94,7 @@ namespace HCore.Web.Providers.Impl
             return new Uri(baseUri + queryBuilder.ToQueryString());
         }
 
-        public virtual async Task<IDownloadFileData> GetFileDataAsync(HttpRequest request, Stream inputData)
+        public virtual async Task<IDownloadFileData> GetFileDataAsync(HttpRequest request, Stream inputData = null)
         {
             if (request == null)
             {


### PR DESCRIPTION
One of the last refactoring dropped the data protector to encode the
has value. Decoding used it, though. So requests always failed.