### PR TITLE
Make sure upper-casing is always done with culture invariant upper-ca…

### DIFF
--- a/HCore-Identity/Services/Impl/IdentityServicesImpl.cs
+++ b/HCore-Identity/Services/Impl/IdentityServicesImpl.cs
@@ -105,7 +105,7 @@ namespace HCore.Identity.Services.Impl
             {
                 if (!string.IsNullOrEmpty(devAdminSsoProtectedUserAccountEmailAddress))
                 {
-                    _devAdminSsoProtectedUserAccountEmailAddresses.Add(devAdminSsoProtectedUserAccountEmailAddress.Trim().ToUpper());
+                    _devAdminSsoProtectedUserAccountEmailAddresses.Add(devAdminSsoProtectedUserAccountEmailAddress.Trim().ToUpperInvariant());
                 }
             });
 
@@ -2084,7 +2084,7 @@ namespace HCore.Identity.Services.Impl
 
         private string Normalize(string input)
         {
-            return input?.Trim().ToUpper();
+            return input?.Trim().ToUpperInvariant();
         }
     }
 }


### PR DESCRIPTION
…se rules. Otherwise, eg. for Turkish culture, i is not I when uppercased